### PR TITLE
Fixing Outline

### DIFF
--- a/style.css
+++ b/style.css
@@ -51,6 +51,7 @@ html {
     border-bottom: 1px solid rgb(226, 226, 226);
     border-right: none;
     border-left: none;
+    outline: none;
     height: 41px;
     width: 499px;
 }
@@ -177,6 +178,7 @@ li:hover {
     font-size: 14px;
     width: 140px;
     color:#3c4043;
+    outline: none;
 }
 
 button {


### PR DESCRIPTION
set outline property to none to avoid the default creation of an outline upon clicking on a button or a text field.